### PR TITLE
Removed extra /n added to end of changelog when edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 0.2.3
+
+Fixed bugs:
+- removed extra newline to CHANGELOG.md file
+
 ## 0.2.2
 
 Fix a bug where the app failed if the library version file was not found.

--- a/main.go
+++ b/main.go
@@ -150,9 +150,8 @@ func saveChangelogFile(filename string, file ChangelogFile) error {
 	defer f.Close()
 
 	w := bufio.NewWriter(f)
-	for _, line := range file.Lines() {
-		fmt.Fprintln(w, line)
-	}
+	contents := strings.Join(file.Lines(), "\n")
+	fmt.Fprint(w, contents)
 	return w.Flush()
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -96,7 +96,7 @@ func TestProcessChangelogFile(t *testing.T) {
 			}
 
 			output := []byte(strings.Join(outFile.Lines(), "\n"))
-			assert.Equal(t, want, output)
+			assert.Equal(t, string(want), string(output))
 		})
 	}
 	assert.Greater(t, cases, 0)


### PR DESCRIPTION
Removed extra `\n` added to the CHANGELOG.md each time it was edited